### PR TITLE
 Refactor ToQtModule implementation : 2 lists -> 1 dict and use .lower()

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,15 @@ optional arguments:
   -s, --show       show result file(s) , use it with recursive option to survey operations
   -s, --config     json file defining dictionnary between CONFIG values in .pro file and cmake function
 ```
+
+# Development (draft)
+
+```
+sudo apt install virtualenv
+cd QMakeToCMake
+virtualenv . # XXX maybe you should do that in another dir ? it will add bin/ include/ lib/ local/ share/
+# the first time could take some time
+. bin/activate
+pip install .
+python -m unittest discover -s q2c
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # QMakeToCMake [![Build Status](https://travis-ci.org/davidtazy/QMake2CMake.svg?branch=master)](https://travis-ci.org/davidtazy/QMake2CMake) [![Coverage Status](https://coveralls.io/repos/github/davidtazy/QMake2CMake/badge.svg?branch=master&service=github)](https://coveralls.io/github/davidtazy/QMake2CMake?branch=master&service=github)
 Helper script to move qmake (Qt5) based subdirs/project to cmake
 
-Warning: its not bullet proof, 
-main goal is too speed up manual operation 
+Warning: it's not bullet proof,
+main goal is to speed up manual operation
 
-will be usefull if lots of pro file to convert
+It will be useful if there are lots of .pro files to convert
 
 # Features:
 - TEMPLATE=subdirs,  you may need to re-order add_subdirectoies lines
@@ -21,7 +21,7 @@ will be usefull if lots of pro file to convert
 - DEFINES
 - INCLUDEPATH
 - CONFIG values and custom variable can define new lines on cmakelist.txt with a json config file (see [example/config.json](example/config.json))
-- 
+
 # Examples
 
 libToto.pro:
@@ -64,24 +64,26 @@ install(TARGETS Toto DESTINATION Libs)
 ```
 # Limitations
 
+q2c does not read correctly conditional blocks:
 ```
-q2c does not read correctly conditionnal blocks:
 CONTAINS(CONFIG,featureXXX): QT+= printsupport
-will be omited during parse
+```
+will be omitted during parse
 
+However, blockIf AND blockElse will be parsed :
+```
 CONTAINS(CONFIG,featureXXX){
 blockIf
 }else{
 blockElse
 }
-blockIf AND blockElse will be parsed 
 ```
 
 # Usage:
 
-download or clone
+Download+extract archive or clone repo, then :
 ```
-cd to QMakeToCMake
+cd QMakeToCMake
 
 pip install .
 # will install commandline app named 'q2c'

--- a/q2c/qmake_to_cmake.py
+++ b/q2c/qmake_to_cmake.py
@@ -4,11 +4,10 @@ import os
 
 
 class QMakeToCMake:
-    Modules = ['Core', 'Widgets', 'Gui', 'Network', 'Sql', 'Multimedia', 'WebKit', 'Svg', 'OpenGL', 'PrintSupport',
-               'Script', 'Xml', 'XmlPatterns', 'Qml', 'Positioning', 'Quick', 'Sensors', 'Sql', 'Declarative','Test']
-    LowerCaseModules = ['core', 'widgets', 'gui', 'network', 'sql', 'multimedia', 'webkit', 'svg', 'opengl',
-                        'printsupport', 'script', 'xml', 'xmlPatterns', 'qml', 'positioning', 'quick', 'sensors', 'sql',
-                        'declarative','testlib']
+    _Modules = ['Core', 'Widgets', 'Gui', 'Network', 'Sql', 'Multimedia', 'WebKit', 'Svg', 'OpenGL', 'PrintSupport',
+               'Script', 'Xml', 'XmlPatterns', 'Qml', 'Positioning', 'Quick', 'Sensors', 'Sql', 'Declarative']  # temporary variable
+    _ModulesSpecialNaming = [('testlib', 'Test')]  # temporary variable
+    _ModulesToQt = dict([(x.lower(), x) for x in _Modules] + _ModulesSpecialNaming)  # used in ToQtModule
 
     def __init__(self):
         self.config_visitor = None
@@ -19,12 +18,7 @@ class QMakeToCMake:
 
     @staticmethod
     def ToQtModule(module):
-
-        l_module = module.lower()
-        if l_module not in QMakeToCMake.LowerCaseModules:
-            return None
-
-        return QMakeToCMake.Modules[QMakeToCMake.LowerCaseModules.index(l_module)]
+        return QMakeToCMake._ModulesToQt.get(module.lower(), None)
 
     def convert(self, pro_file):
         qmake = QMakeParser()


### PR DESCRIPTION
I wanted to make a separate PR, one for readme and another for the refactor, but now that I've commited both, I can't see how to do that efficiently.

About the refactor :

**Do you trust your tests ? I've only run `python -m unittest discover q2c` (which says OK)**

https://github.com/davidtazy/QMake2CMake/blob/0d1115131e4ae7ed1ab6d235fd26cb39e05affe6/q2c/qmake_to_cmake.py#L7-L11
https://github.com/davidtazy/QMake2CMake/blob/0d1115131e4ae7ed1ab6d235fd26cb39e05affe6/q2c/qmake_to_cmake.py#L21-L27

- I found the manual lowercasing ... disturbing.
- Those two lists work like a dict, so why not ?
